### PR TITLE
44 fix karma history query

### DIFF
--- a/App/controllers/karma.py
+++ b/App/controllers/karma.py
@@ -6,7 +6,7 @@ from .transcript import (calculate_academic_score)
 
 
 def get_karma(studentID):
-  karma = Karma.query.filter_by(studentID=studentID).order_by(Karma.timestamp.desc()).first()
+  karma = Karma.query.filter_by(studentID=studentID).order_by(Karma.karmaID.desc()).first()
   if karma:
     return karma
   else:
@@ -14,14 +14,14 @@ def get_karma(studentID):
 
 
 def get_karma_history(studentID):
-  history = Karma.query.filter_by(studentID = studentID).order_by(Karma.timestamp.desc())
+  history = Karma.query.filter_by(studentID = studentID).order_by(Karma.karmaID.desc())
   if history:                                                                                  #FOR GRAPH, IF BREAK ITS HERE
     return history
   else:
     return None
 
 def get_karma_student(student):
-  karma = Karma.query.filter_by(studentID=student.ID).order_by(Karma.timestamp.desc()).first()
+  karma = Karma.query.filter_by(studentID=student.ID).order_by(Karma.karmaID.desc()).first()
   if karma:
     return karma
   else:

--- a/App/models/student.py
+++ b/App/models/student.py
@@ -92,7 +92,7 @@ class Student(User, StudentInterface):
 
   def get_karma(self):
       if self.karma_history:
-          return max(self.karma_history, key=lambda k: k.timestamp)  # Get latest karma entry
+          return max(self.karma_history, key=lambda k: k.karmaID)  # Get latest karma entry
       return None
 
 

--- a/App/templates/Student-Profile-forStaff.html
+++ b/App/templates/Student-Profile-forStaff.html
@@ -867,7 +867,7 @@ src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.js">
     // URLs corresponding to each karma point (modify URL pattern as needed) - /viewKarmaDetail/{{ karma.id }}
     const urls = [
         {% for review in history|reverse %}
-            "/jsreview/{{ review.reviewID - 1}}"{% if not loop.last %}, {% endif %}
+            "/jsreview/{{ review.reviewID}}"{% if not loop.last %}, {% endif %}
         {% endfor %}
     ];
 


### PR DESCRIPTION
Fixed karma queries so they are sorted by karma ID. Sorting by timestamps, as it was done previously, could lead to inconsistencies in which karma record would be used for the update, since multiple distinct karma records could have the same timestamp, as is the case in our sample data init.